### PR TITLE
Update developer section

### DIFF
--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.35-SNAPSHOT</version>
+	<version>0.0.35</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.35-SNAPSHOT</version>
+		<version>0.0.35</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.34-SNAPSHOT</version>
+	<version>0.0.34</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.34-SNAPSHOT</version>
+		<version>0.0.34</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.31</version>
+	<version>0.0.32-SNAPSHOT</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.31</version>
+		<version>0.0.32-SNAPSHOT</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.32-SNAPSHOT</version>
+	<version>0.0.32</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.32-SNAPSHOT</version>
+		<version>0.0.32</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.33-SNAPSHOT</version>
+	<version>0.0.33</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.33-SNAPSHOT</version>
+		<version>0.0.33</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.33</version>
+	<version>0.0.34-SNAPSHOT</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.33</version>
+		<version>0.0.34-SNAPSHOT</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.34</version>
+	<version>0.0.35-SNAPSHOT</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.34</version>
+		<version>0.0.35-SNAPSHOT</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.31-SNAPSHOT</version>
+	<version>0.0.31</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.31-SNAPSHOT</version>
+		<version>0.0.31</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.35</version>
+	<version>0.0.36-SNAPSHOT</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.35</version>
+		<version>0.0.36-SNAPSHOT</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/codera-maven-github/pom.xml
+++ b/codera-maven-github/pom.xml
@@ -4,12 +4,12 @@
 
 	<artifactId>codera-parent-github</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.32</version>
+	<version>0.0.33-SNAPSHOT</version>
 
 	<parent>
 		<groupId>uk.co.codera</groupId>
 		<artifactId>codera-parent</artifactId>
-		<version>0.0.32</version>
+		<version>0.0.33-SNAPSHOT</version>
 	</parent>	
 
 	<description>Parent pom file for Codera maven github projects</description>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
         </license>
     </licenses>
 
-    <developers>
+<!--     <developers>
         <developer>
             <name>Andy Stewart</name>
             <email>andy.stewart@codera.co.uk</email>
             <organization>Codera</organization>
             <organizationUrl>http://www.codera.co.uk</organizationUrl>
         </developer>
-    </developers>
+    </developers> -->
 
     <scm>
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
         </license>
     </licenses>
 
-<!--     <developers>
+    <developers>
         <developer>
-            <name>Andy Stewart</name>
-            <email>andy.stewart@codera.co.uk</email>
+            <name>Codera Team</name>
+            <email>codera.release.user@codera.co.uk</email>
             <organization>Codera</organization>
             <organizationUrl>http://www.codera.co.uk</organizationUrl>
         </developer>
-    </developers> -->
+    </developers>
 
     <scm>
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.34-SNAPSHOT</version>
+    <version>0.0.34</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>HEAD</tag>
+        <tag>codera-parent-0.0.34</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.31-SNAPSHOT</version>
+    <version>0.0.31</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>HEAD</tag>
+        <tag>codera-parent-0.0.31</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.35</version>
+    <version>0.0.36-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>codera-parent-0.0.35</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.32</version>
+    <version>0.0.33-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>codera-parent-0.0.32</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.31</version>
+    <version>0.0.32-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>codera-parent-0.0.31</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.32-SNAPSHOT</version>
+    <version>0.0.32</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>HEAD</tag>
+        <tag>codera-parent-0.0.32</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.35-SNAPSHOT</version>
+    <version>0.0.35</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>HEAD</tag>
+        <tag>codera-parent-0.0.35</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.33</version>
+    <version>0.0.34-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>codera-parent-0.0.33</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.34</version>
+    <version>0.0.35-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>codera-parent-0.0.34</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>uk.co.codera</groupId>
     <artifactId>codera-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.33-SNAPSHOT</version>
+    <version>0.0.33</version>
 
     <name>${project.artifactId}</name>
     <description>Parent pom file for Codera maven projects</description>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:coderauk/maven.git</connection>
         <developerConnection>scm:git:git@github.com:coderauk/maven.git</developerConnection>
         <url>git@github.com:coderauk/maven.git</url>
-        <tag>HEAD</tag>
+        <tag>codera-parent-0.0.33</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
NOTE: The new developer e-mail does not actually exist. There was no need for now- perhaps add later (probably useful for contributors on the open source project to contact us).

PREMISE: Initially this branch was supposed to enable automatic nexus releases to both ossrh (the open source repository manager where only the codera-parent lives) AND codera-nexus (the latter one was not happening). 

PROBLEM: However, it's impossible to add multiple distribution management repositories- though there are workarounds that seem messy! It is assumed that before they were being manually uploaded to the private nexus server (codera-nexus). 

SOLUTION: A more suitable, easier and future proof solution is to edit your .m2/settings.xml file and add a mirror to codera-nexus (see below). This will make sure to first check the ossrh server for any dependencies (this will be especially useful when multiple projects get released there), then codera-nexus (the private internal one) and then maven central, if you have your mirrors set up like this:


```
  <mirrors>
      <mirror>
          <id>ossrh</id>
          <url>https://oss.sonatype.org/content/repositories/releases</url>
          <mirrorOf>codera-nexus</mirrorOf>
      </mirror>
      <mirror>
          <id>codera-nexus</id>
           <url>https://dev.codera.co.uk/nexus/content/groups/public</url>
          <mirrorOf>central</mirrorOf>
      </mirror>
  </mirrors>
```